### PR TITLE
Use MacOSARP2 scanner for FreeBSD

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,8 @@ var Arped = function () {
             } else {
                 this.arpFetcher = new _LinuxARP2.default();
             }
+        } else if (/freebsd/.test(process.platform)) {
+            this.arpFetcher = new _MacOSARP2.default();
         } else if (/darwin/.test(process.platform)) {
             this.arpFetcher = new _MacOSARP2.default();
         } else if (/^win/.test(process.platform)) {


### PR DESCRIPTION
How about supporting FreeBSD by utilizing MacOSARP2 that just executes arp command?